### PR TITLE
fix: avoid automatic append from trailing slash in customer urls

### DIFF
--- a/challenge/challenge/settings.py
+++ b/challenge/challenge/settings.py
@@ -138,3 +138,5 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Expiration in days
 TOKEN_EXPIRATION = int(os.environ.get('TOKEN_EXPIRATION', 30))
+
+APPEND_SLASH=False


### PR DESCRIPTION
setting up APPEND_SLASH like false from django settings to avoid automatic append trailing slash in customer views